### PR TITLE
fixed so that season stats table is filled before game stats table to…

### DIFF
--- a/backend/script/fillGameTable.js
+++ b/backend/script/fillGameTable.js
@@ -11,13 +11,12 @@ const fillGameTable = (date) => {
     })
     queryInputGamesStats = queryInputGamesStats.slice(0, -1) + ";";
     
-    return db 
+     return db 
       .query(queryInputGamesStats)
       .then((result) => {
-        console.log("in the DB")
-        res.json({data: result.rows})
+        console.log("fillGameTable: insterted into the DB", date)
       })
-      .catch((err) => err);
+      .catch((err) => console.log("@fillGameTable, Date:", date, " Error:", err));
   })
   .catch(error => {
     console.log(error);

--- a/backend/script/fillTables.js
+++ b/backend/script/fillTables.js
@@ -1,8 +1,11 @@
 const axios = require('axios');
 const db = require('../db');
+const fillGameTable = require('./fillGameTable.js');
+
 
 const fillSeasonTable = () => {
   let queryInputSeasonStats = "INSERT INTO players_season_stats(playerID, name, team, position, games, fantasyPoints, minutes, seconds, fieldGoalsMade, fieldGoalsAttempted, fieldGoalsPercentage, effectiveFieldGoalsPercentage, twoPointersMade, twoPointersAttempted, twoPointersPercentage, threePointersMade, threePointersAttempted, threePointersPercentage, freeThrowsMade, freeThrowsAttempted, freeThrowsPercentage, offensiveRebounds, defensiveRebounds, rebounds, offensiveReboundsPercentage, defensiveReboundsPercentage, totalReboundsPercentage, assists, steals, blockedShots, turnovers, personalFouls, points, trueShootingAttempts, trueShootingPercentage, playerEfficiencyRating, assistsPercentage, stealsPercentage, blocksPercentage, turnOversPercentage, usageRatePercentage, fantasyPointsFanDuel, fantasyPointsDraftKings, fantasyPointsYahoo, plusMinus, doubleDoubles, tripleDoubles, fantasyPointsFantasyDraft) VALUES";
+
   axios.get('https://api.sportsdata.io/v3/nba/stats/json/PlayerSeasonStats/2022', {headers: {"Ocp-Apim-Subscription-Key":"ce0935001bf94813a935f4593acd1514"}})
   .then(response => {
     response.data.map((player) => {
@@ -10,13 +13,19 @@ const fillSeasonTable = () => {
     })
     queryInputSeasonStats = queryInputSeasonStats.slice(0, -1) + ";";
     
-    return db 
+     return db 
       .query(queryInputSeasonStats)
       .then((result) => {
-        console.log("in the DB")
-        res.json({data: result.rows})
+        console.log("fillSeasonTable: inserted into the DB");
+        Promise.all([
+          fillGameTable("2021-NOV-23"),
+          fillGameTable("2021-NOV-22"),
+          fillGameTable("2021-NOV-21"),
+          fillGameTable("2021-NOV-20"),
+          fillGameTable("2021-NOV-19")
+        ]);
       })
-      .catch((err) => err);
+      .catch((err) => console.log("@fillSeasonTable, Error:", err));
   })
   .catch(error => {
     console.log(error);

--- a/backend/script/sportApi.js
+++ b/backend/script/sportApi.js
@@ -1,21 +1,15 @@
 const express = require('express');
 const sportApi = express.Router();
-const fillSeasonTable = require('./fillSeasonTable.js');
-const fillGameTable = require('./fillGameTable.js');
-
-
-
-
-
+const fillTables = require('./fillTables.js');
 
 sportApi.get('/all', function(req, res) {
 
-  fillSeasonTable();
-  fillGameTable("2021-NOV-23");
-  fillGameTable("2021-NOV-22");
-  fillGameTable("2021-NOV-21");
-  fillGameTable("2021-NOV-20");
-  fillGameTable("2021-NOV-19");
+  Promise.all([fillTables()]).then(() => {
+    res.status(201).json({ msg: "Great Success!"});
+  }).catch((err) => {
+    console.log(err);
+    res.status(404).json({ msg: "Error"});
+  });
 
 })
 


### PR DESCRIPTION
… avoid foreign key errors using Promises


I realized there was inconsistency with the db inserts because sometimes the sportsapi would return its data out of order... basically the players_game_stats table has a foreign key playerid which depends on players_season_stats being filled. My fix basically ensures that this happens by hiding the fillGameTable calls within then() of the players_season_stats db insert.